### PR TITLE
check for NaN on score

### DIFF
--- a/lib/fuzzy_tools/tf_idf_index.rb
+++ b/lib/fuzzy_tools/tf_idf_index.rb
@@ -37,7 +37,7 @@ module FuzzyTools
 
         score = self.score(query_weighted_tokens, candidate_tokens)
 
-        [candidate, score]
+        [candidate, (score.nan? ? 0.0 : score)]
       end
     end
 


### PR DESCRIPTION
This fixes an Argument exception
```
ArgumentError: comparison of Array with Array failed
~/.rvm/gems/ruby-2.4.2/gems/fuzzy_tools-1.0.0/lib/fuzzy_tools/index.rb:25:in `sort_by'
~/.rvm/gems/ruby-2.4.2/gems/fuzzy_tools-1.0.0/lib/fuzzy_tools/index.rb:25:in `all_with_scores'
~/.rvm/gems/ruby-2.4.2/gems/fuzzy_tools-1.0.0/lib/fuzzy_tools/core_ext/enumerable.rb:16:in `fuzzy_find_all_with_scores'
```